### PR TITLE
Using native node.js queryString instead of 3rd party package

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,4 +1,4 @@
-const queryString = require('query-string');
+const queryString = require('querystring');
 const createNodeHelpers = require('gatsby-node-helpers').default;
 const eventbrite = require('eventbrite').default;
 


### PR DESCRIPTION
I noticed that for `queryString.stringify` method, a 3rd party package was used in this file - `query-string`
But I don't see the need for it, as node.js offers that feature out of the box.
I have tested this by passing config appropriately

```
{
      resolve: 'gatsby-plugin-source-eventbrite',
      options: {
        query: {
          'location.address': 'Vancouver',
          'location.within': '10km',
          categories: '110',
          expand: ['venue'],
        },
        token: process.env.EVENTBRITE_ACCESS_TOKEN,
      },
```
